### PR TITLE
Correct event signup link

### DIFF
--- a/content/events.md
+++ b/content/events.md
@@ -1,7 +1,7 @@
 ---
 title: 'Events'
 ---
-If you would like to sign up to our event series please register [here](shiny.link/Jl6nuV).
+If you would like to sign up to our event series please register [here](https://shiny.link/Jl6nuV).
  
 ----
 ### FAIRPoints  


### PR DESCRIPTION
At the top of https://www.fairpoints.org/events/
in the link of "here" in "If you would like to sign up to our event series please register [here](shiny.link/Jl6nuV)"

It is incorrectly leading to https://www.fairpoints.org/events/shiny.link/Jl6nuV
resulting in "Page not found"

I've corrected it to
https://shiny.link/Jl6nuV

which now correctly points to the Google form, https://docs.google.com/forms/d/e/1FAIpQLSeMamMgEs9iT73yuihsHrWQlRLDgyO6gzY-BIzGvbwTNEV7ZA/viewform