### PR TITLE
feat: show teaches elements

### DIFF
--- a/data/points/fpr001.json
+++ b/data/points/fpr001.json
@@ -56,7 +56,7 @@
     "How to make the benefits of FAIR visible to academic researchers", "Researchers are afraid of being scooped and don't understand licensing and ownership as well as how to choose conditions in publishing in repos",
     "Alot of metadata is expected, adding a level of effort in curation, labor intensive process which can be made easier if researchers provide accurate and detailed information from the start"
   ],
-  "teaches": [ "FAIR is a set of guiding principles, do you have examples for practical implementation choices that are being made within your community of practice?", "FAIRification efforts in the materials science community: a common API for serving data: https://www.optimade.org/, data repositories: https://nomad-lab.eu/, https://archive.materialscloud.org/, https://mpcontribs.org/",
+  "teaches": [ "FAIR is a set of guiding principles, do you have examples for practical implementation choices that are being made within your community of practice?", "FAIRification efforts in the materials science community: a common API for serving data: <https://www.optimade.org/>, data repositories: <https://nomad-lab.eu/>, <https://archive.materialscloud.org/>, https://mpcontribs.org/",
     "Domain-specific implementation profiles and examples: https://www.go-fair.org/how-to-go-fair/fair-implementation-profile/ , https://www.go-fair.org/implementation-networks/overview/",
     "How to be FAIR with your data: A teaching and training handbook for higher education institutions (https://doi.org/10.5281/zenodo.5665492).",
     "Article: https://crl.acrl.org/index.php/crl/article/view/23610/30923",

--- a/layouts/partials/fpr_card.html
+++ b/layouts/partials/fpr_card.html
@@ -16,6 +16,11 @@
     </ul>
     <br>
     <h4>FAIRPoints</h4>
+    <ul>
+        {{ range .teaches }}
+        <li>{{ . | markdownify }}</li>
+        {{ end }}
+    </ul>
 
 
     <p>Date Published: {{ .datePublished }} <br> Version: {{ .version }}</p>


### PR DESCRIPTION
To parse the elements of a list of unstructured things (like the "teaches" list, which is just strings), the Go templating language that Hugo uses interprets a plain dot `{{ . }}` as the element. Whereas when list elements are structured, as with "author", you do things like `{{ .name }}` to get at the attributes of each structured element of the list.

What I also added here was the use of [a template function](https://gohugo.io/functions/markdownify/) to interpret the teaches element as a markdown string. This is nice in this case because it will create links out of the "http://..." parts. Although, it looks like it messes up when a comma follows a last slash in a url, so I put brackets around a few urls to make them display properly.