### PR TITLE
Moved FAIR4Beginners event from upcoming to previous events

### DIFF
--- a/content/events.md
+++ b/content/events.md
@@ -7,30 +7,34 @@ If you would like to sign up to our event series please register [here](https://
 ## Upcoming events
 
 ----
-### FAIR4Beginners
-
-
 
 
 ----
 ## Previous events
 ----
+### FAIR4Beginners
+This is a first of a series of events designed to bring the community together to co-create material needed in different formats, e.g. training slides, guidebooks, video/animations, infographics etc.
+
+Date: September 30, 2022\
+Time: 16:00-18:00 CEST
+
+----
 ### Enhancing Sample Provenance and Experimental Reproducibility
 Lack of reliable information about sample usage, location, provenance, metadata and experimental use is a core barrier to experimental reproducibility and general FAIRification of data.  This presentation will describe how these issues are being addressed in the design and development of a sample management module within the RSpace electronic lab notebook, focusing on three specific challenges: (1) Incorporating sample data into experimental documentation; (2) Associating PIDS like IGSNs and RRIDS into sample metadata; and (3) Export of sample metadata in required formats to different domain repositories and databases.
 
-Speaker: Rory Macneil
-
-Date: May 30, 2022
-Time: 16:00-17:00 CEST, see in [you time zone](https://arewemeetingyet.com/Stockholm/2022-05-30/16:00/FAIRPoints-Enhancing%20Sample%20Provenance%20and%20Experimental%20Reproducibility%20#eyJ1cmwiOiJodHRwczovL3V1LXNlLnpvb20udXMvai83MTQ1NDUyNjExIn0=)
+Speaker: Rory Macneil\
+Date: May 30, 2022\
+Time: 16:00-17:00 CEST
 
 **Recording** available [here](https://youtu.be/7kDTNHrav3E)
 
+----
 ### Things you need to know about Data Access Statements
 Data access statements (DAS), also known as data availability statements, are key elements that can be used in multiple diverse disciplines and have a huge impact in providing essential information as it outlines where and how any underlying data may be accessed and reused, listing specific restrictions (if any) and the authorization process. It is therefore integral to the FAIRification process. Join us in this talk to discover how an effective data access statement should look like!
 
 Speaker: Juliane Schneider & Chris Erdmann           
 Date: April 21, 2022  
-Time: 15:00 - 16:00 CEST, see in [your time zone](https://arewemeetingyet.com/Stockholm/2022-04-21/15:00/Things%20you%20need%20to%20know%20about%20Data%20Access%20Statements)
+Time: 15:00 - 16:00 CEST
 
 **Recording** available [here](https://youtu.be/rpx57qnCGx8)
 
@@ -43,7 +47,7 @@ FAIR mechanisms have pioneered a new paradigm of making data discoverable, acces
 
 Speaker: Harshvardhan J. Pandit           
 Date: March 23, 2022  
-Time: 16:00 - 17:00 CEST, see in [your time zone](https://arewemeetingyet.com/Stockholm/2022-03-23/16:00/Harmonising%20FAIR%20data%20sharing%20with%20Legal%20Compliance)
+Time: 16:00 - 17:00 CEST
 
 **Recording** available [here](https://www.youtube.com/watch?v=fTEw6K8YSIQ)
 
@@ -56,7 +60,7 @@ In this talk, we will explore the open source publishing platform [ResearchEqual
 
 Speaker: Chris Hartgerink             
 Date: February 24, 2022  
-Time: 15:00 - 16:00 CEST, see in [your time zone](https://arewemeetingyet.com/Stockholm/2022-02-24/15:00/Step%20by%20Step%20Publishing)
+Time: 15:00 - 16:00 CEST
 
 **Recording** available [here](https://www.youtube.com/watch?v=CD-nJzA9Xg4&t=6s)
 
@@ -69,7 +73,7 @@ Time: 15:00 - 16:00 CEST, see in [your time zone](https://arewemeetingyet.com/St
 First community discussion exploring challenges, opportunities and pragmatic measures towards the implementation of the FAIR data principles, part of event series developed by [GoFAIR US](https://www.go-fair.org/), [SDSC](https://www.sdsc.edu/), [AGU](https://www.agu.org/), and [SciLifeLab Data Centre](https://www.scilifelab.se/data).
 
 Date: January 28, 2022  
-Time: 17:00 - 18:00 CEST, see in [your time zone](https://arewemeetingyet.com/Stockholm/2022-01-28/17:00/FAIRPoints#eyJ1cmwiOiJodHRwczovL3d3dy5zY2lsaWZlbGFiLnNlL2V2ZW50L2ZhaXJwb2ludHMvIn0=)  
+Time: 17:00 - 18:00 CEST  
 
 **Recording** available [here](https://youtu.be/1dEv5x5imBw)
 


### PR DESCRIPTION
Moved FAIR4Beginners event from upcoming to previous events. 

I also removed the inks to display the event time is different time zones as I noticed that those link doesn't show any info once the event has passed. 